### PR TITLE
Fixed unable to scan project by Godot 2.1.4 

### DIFF
--- a/buildConfig/engine_android.cfg
+++ b/buildConfig/engine_android.cfg
@@ -60,7 +60,7 @@ certificates="res://assets/dst.crt"
 
 [tof]
 
-ENV=prod
+ENV="prod"
 default_zoom=0.5
 selector_offset=0
 resolution_override=false

--- a/buildConfig/engine_desktop.cfg
+++ b/buildConfig/engine_desktop.cfg
@@ -60,7 +60,7 @@ certificates="res://assets/dst.crt"
 
 [tof]
 
-ENV=prod
+ENV="prod"
 default_zoom=0.5
 selector_offset=0
 resolution_override=true

--- a/buildConfig/engine_linux32.cfg
+++ b/buildConfig/engine_linux32.cfg
@@ -60,7 +60,7 @@ certificates="res://assets/dst.crt"
 
 [tof]
 
-ENV=prod
+ENV="prod"
 default_zoom=0.5
 selector_offset=0
 resolution_override=true

--- a/buildConfig/engine_osx.cfg
+++ b/buildConfig/engine_osx.cfg
@@ -60,7 +60,7 @@ certificates="res://assets/dst.crt"
 
 [tof]
 
-ENV=prod
+ENV="prod"
 default_zoom=0.5
 selector_offset=0
 resolution_override=true

--- a/game.xscn
+++ b/game.xscn
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<resource_file type="PackedScene" subresource_count="7" version="2.1" version_name="Godot Engine v2.1.4.stable.official">
+<resource_file type="PackedScene" subresource_count="7" version="2.1" version_name="Godot Engine v2.1.stable.official">
 	<ext_resource path="res://scripts/game_logic.gd" type="Script" index="1"></ext_resource>
 	<ext_resource path="res://gui/corners.xscn" type="PackedScene" index="2"></ext_resource>
-	<ext_resource path="res://gui/default_theme.tres" type="Theme" index="0"></ext_resource>
 	<ext_resource path="res://scripts/camera.gd" type="Script" index="4"></ext_resource>
+	<ext_resource path="res://gui/default_theme.tres" type="Theme" index="0"></ext_resource>
 	<ext_resource path="res://scripts/demo_timer.gd" type="Script" index="3"></ext_resource>
 	<resource type="SampleLibrary" path="local://1">
 
@@ -135,7 +135,7 @@
 				<resource name=""></resource>				<int> 500 </int>
 				<real> 12 </real>
 				<resource  external="3">  </resource>
-				<rect2> 0, 0, 1024, 576 </rect2>
+				<rect2> 0, 0, 1280, 720 </rect2>
 				<vector2> 1, 1 </vector2>
 				<int> -10000000 </int>
 				<int> 10000000 </int>

--- a/game.xscn
+++ b/game.xscn
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<resource_file type="PackedScene" subresource_count="7" version="2.1" version_name="Godot Engine v2.1.stable.official">
+<resource_file type="PackedScene" subresource_count="7" version="2.1" version_name="Godot Engine v2.1.4.stable.official">
 	<ext_resource path="res://scripts/game_logic.gd" type="Script" index="1"></ext_resource>
 	<ext_resource path="res://gui/corners.xscn" type="PackedScene" index="2"></ext_resource>
-	<ext_resource path="res://scripts/camera.gd" type="Script" index="4"></ext_resource>
 	<ext_resource path="res://gui/default_theme.tres" type="Theme" index="0"></ext_resource>
+	<ext_resource path="res://scripts/camera.gd" type="Script" index="4"></ext_resource>
 	<ext_resource path="res://scripts/demo_timer.gd" type="Script" index="3"></ext_resource>
 	<resource type="SampleLibrary" path="local://1">
 
@@ -135,7 +135,7 @@
 				<resource name=""></resource>				<int> 500 </int>
 				<real> 12 </real>
 				<resource  external="3">  </resource>
-				<rect2> 0, 0, 1280, 720 </rect2>
+				<rect2> 0, 0, 1024, 576 </rect2>
 				<vector2> 1, 1 </vector2>
 				<int> -10000000 </int>
 				<int> 10000000 </int>


### PR DESCRIPTION
Checked and tested by seeing debug log from Godot. It cannot recognize `prod` as set in `engine.cfg` so project cannot be scanned.
 
Attach error log here

```
haxpors-mbp:MacOS haxpor$ ./Godot -vde -path ~/Downloads/Tanks-of-Freedom/engine.cfg 
arguments
0: ./Godot
1: -vde
2: -path
3: /Users/haxpor/Downloads/Tanks-of-Freedom/engine.cfg
ERROR: load: ConfgFile::load - /Users/haxpor/Downloads/Tanks-of-Freedom/engine.cfg:62 error: Unexpected identifier: 'prod'.
   At: core/io/config_file.cpp:183.
ERROR: _load_recent_projects: Condition ' err != OK ' is true. Continuing..:
   At: editor/project_manager.cpp:801.
ERROR: free_static: Condition ' !MemoryPoolStatic::get_singleton() ' is true.
   At: core/os/memory.cpp:59.
ERROR: free_static: Condition ' !MemoryPoolStatic::get_singleton() ' is true.
   At: core/os/memory.cpp:59.
```